### PR TITLE
feat: Enforce branch PR restrictions and update README

### DIFF
--- a/.github/workflows/firebase-hosting-pull-request.yml
+++ b/.github/workflows/firebase-hosting-pull-request.yml
@@ -19,6 +19,18 @@ jobs:
     runs-on: ubuntu-latest
 
     steps:
+      - name: Check PR source branch
+        run: |
+          if [[ "${{ github.base_ref }}" == "prod" && "${{ github.head_ref }}" != "test" ]]; then
+            echo "PRs to prod must come from test."
+            exit 1
+          elif [[ "${{ github.base_ref }}" == "test" && "${{ github.head_ref }}" != "dev" ]]; then
+            echo "PRs to test must come from dev."
+            exit 1
+          else
+            echo "PR branch restrictions met."
+          fi
+        shell: bash
 
       - name: Checkout public repository
         uses: actions/checkout@v4

--- a/.github/workflows/protect-main-prs.yml
+++ b/.github/workflows/protect-main-prs.yml
@@ -1,0 +1,20 @@
+name: Protect Main Branch PRs
+
+on:
+  pull_request:
+    branches:
+      - main
+
+jobs:
+  check_pr_source_branch:
+    runs-on: ubuntu-latest
+    steps:
+      - name: Check if PR is from prod
+        if: github.head_ref != 'prod'
+        run: |
+          echo "Pull requests to main must come from the prod branch."
+          exit 1
+      - name: Approve PR from prod
+        if: github.head_ref == 'prod'
+        run: |
+          echo "Pull request to main is from prod. Approved."

--- a/README.md
+++ b/README.md
@@ -71,6 +71,25 @@ npm run deploy
 - `sudo xcode-select -s /Applications/Xcode.app/Contents/Developer`: Set Xcode developer directory
 - `npm install expo-speech-recognition`: Example of adding a specific Expo package
 
+## Branching Strategy
+
+This project follows a specific branching strategy to ensure code quality and stability:
+
+- `main` only accepts Pull Requests (PRs) from `prod`.
+- `prod` only accepts PRs from `test`.
+- `test` only accepts PRs from `dev`.
+- `dev` can accept PRs from feature branches.
+
+This flow ensures that code is thoroughly tested and reviewed before it reaches the `main` branch.
+
+```mermaid
+graph LR
+    feature_branches --> dev;
+    dev --> test;
+    test --> prod;
+    prod --> main;
+```
+
 ## Preview Channels
 
 You can access live previews of different branches:


### PR DESCRIPTION
This commit introduces a stricter branching strategy and enforces it via GitHub Actions.

The following changes have been made:

1.  **README.md Updated:**
    *   Added a new "Branching Strategy" section.
    *   This section explains the required PR flow: `dev` -> `test` -> `prod` -> `main`.
    *   Included a Mermaid diagram to visually represent this flow.

2.  **GitHub Actions Workflow for `main` Branch PRs (`protect-main-prs.yml`):**
    *   A new workflow has been created that triggers on pull requests targeting the `main` branch.
    *   It ensures that pull requests to `main` can only originate from the `prod` branch. If not, the workflow fails.

3.  **Updated `firebase-hosting-pull-request.yml`:**
    *   This existing workflow, which handles PRs to other branches for Firebase preview deployments, has been modified.
    *   It now includes checks to ensure:
        *   Pull requests to the `prod` branch only come from the `test` branch.
        *   Pull requests to the `test` branch only come from the `dev` branch.
    *   If these conditions are not met, the workflow will fail.

These changes ensure that code promotion through the branches follows the defined path, enhancing stability and control over the release process.