### PR TITLE
Fix: Handle dynamic Firebase preview URLs in deployment verification

### DIFF
--- a/.github/workflows/deploy-firebase.yml
+++ b/.github/workflows/deploy-firebase.yml
@@ -129,14 +129,26 @@ jobs:
         env:
           CHANNEL_ID_OUTPUT: ${{ steps.channel_id.outputs.channel_id }}
           FIREBASE_PROJECT_ID: mapchatai
+          FIREBASE_DEPLOY_DETAILS: ${{ steps.firebase_deploy.outputs.details }}
         run: |
-          sudo apt-get update && sudo apt-get install -y jq
-          DEPLOYED_VERSION_URL=""
+          sudo apt-get update && sudo apt-get install -y jq # Keep this line
+          echo "Firebase Deploy Details: $FIREBASE_DEPLOY_DETAILS" # For debugging
+
+          ACTUAL_SITE_URL=""
           if [ "$CHANNEL_ID_OUTPUT" == "live" ]; then
-            DEPLOYED_VERSION_URL="https://$FIREBASE_PROJECT_ID.web.app/version.json"
+            ACTUAL_SITE_URL=$(echo "$FIREBASE_DEPLOY_DETAILS" | jq -r --arg project_id "$FIREBASE_PROJECT_ID" '.[$project_id].live.url')
           else
-            DEPLOYED_VERSION_URL="https://$FIREBASE_PROJECT_ID--$CHANNEL_ID_OUTPUT.web.app/version.json"
+            # Find the key that starts with the CHANNEL_ID_OUTPUT (e.g., "preview-dev")
+            # The channel ID from firebase_deploy details might have a suffix (e.g., "preview-dev-randomsuffix")
+            ACTUAL_SITE_URL=$(echo "$FIREBASE_DEPLOY_DETAILS" | jq -r --arg project_id "$FIREBASE_PROJECT_ID" --arg channel_prefix "$CHANNEL_ID_OUTPUT" '.[$project_id] | to_entries[] | select(.key | startswith($channel_prefix)) | .value.url')
           fi
+
+          if [ -z "$ACTUAL_SITE_URL" ] || [ "$ACTUAL_SITE_URL" == "null" ]; then
+            echo "::error::Could not extract site URL from Firebase deployment details."
+            exit 1
+          fi
+
+          DEPLOYED_VERSION_URL="$ACTUAL_SITE_URL/version.json"
           echo "Fetching deployed version from: $DEPLOYED_VERSION_URL"
           for i in 1 2 3 4 5; do
             HTTP_CODE=$(curl -s -w "%{http_code}" -o response.json $DEPLOYED_VERSION_URL)

--- a/README.md
+++ b/README.md
@@ -87,12 +87,14 @@ All automated deployments are contingent upon the successful completion of build
     *   **Purpose**: Preview deployments for feature branches.
     *   **Triggered by**: Pushes to any branch *other than* `main`.
     *   **URL**: `https://mapchatai--preview-<sanitized-branch-name>.web.app` (e.g., `https://mapchatai--preview-dev.web.app` for the `dev` branch).
+    *   Note: Firebase may append a unique identifier to this URL (e.g., `https://mapchatai--preview-dev-xxxxxxx.web.app`). The deployment system automatically handles this.
     *   **Channel ID**: `preview-<sanitized-branch-name>`
 
 *   **Pull Request Preview Channels**:
     *   **Purpose**: Preview deployments for active Pull Requests.
     *   **Triggered by**: Opening or updating a Pull Request (targeting any branch).
     *   **URL**: `https://mapchatai--preview-pr-<pr-number>.web.app` (e.g., `https://mapchatai--preview-pr-123.web.app` for PR #123).
+    *   Note: Firebase may append a unique identifier to this URL (e.g., `https://mapchatai--preview-pr-123-xxxxxxx.web.app`). The deployment system automatically handles this.
     *   **Channel ID**: `preview-pr-<pr-number>`
 
 *   **Workflow**: `deploy-firebase.yml`


### PR DESCRIPTION
- Modifies the GitHub Actions workflow (`.github/workflows/deploy-firebase.yml`) to capture the actual deployment URL from the Firebase deploy action's output.
- This ensures that the verification step uses the correct URL, even when Firebase appends a dynamic suffix to preview channel URLs (e.g., for 'dev' or PR previews).
- Updates `README.md` to document this behavior and that I handle it automatically.