### PR TITLE
Extract Firebase channel logic

### DIFF
--- a/ExpoGallery/scripts/getFirebaseChannelId.js
+++ b/ExpoGallery/scripts/getFirebaseChannelId.js
@@ -1,0 +1,52 @@
+function sanitizeBranchName(name) {
+  if (!name) return '';
+  let sanitized = name.toLowerCase();
+  sanitized = sanitized.replace(/[^a-z0-9-]/g, '-');
+  sanitized = sanitized.slice(0, 36);
+  sanitized = sanitized.replace(/^-+/, '').replace(/-+$/, '');
+  return sanitized;
+}
+
+function getFirebaseChannelId(ctx) {
+  const { eventName, ref, refName, eventNumber, inputs = {} } = ctx;
+
+  if (eventName === 'push' && ref === 'refs/heads/main') {
+    return 'live';
+  } else if (eventName === 'push') {
+    const branch = sanitizeBranchName(refName);
+    const name = branch || 'preview';
+    return `preview-${name}`;
+  } else if (eventName === 'pull_request') {
+    return `preview-pr-${eventNumber}`;
+  } else if (eventName === 'workflow_dispatch') {
+    const inputBranch = inputs.branch || '';
+    const branch = sanitizeBranchName(inputBranch);
+    const normalized = inputBranch.toLowerCase();
+    if (normalized === 'main') {
+      return 'live';
+    } else if (!branch) {
+      return 'preview-manual';
+    } else {
+      return `preview-${branch}`;
+    }
+  }
+  throw new Error('Unknown event type or context for Firebase deployment.');
+}
+
+module.exports = { sanitizeBranchName, getFirebaseChannelId };
+
+if (require.main === module) {
+  const fs = require('fs');
+  const context = {
+    eventName: process.env.GITHUB_EVENT_NAME,
+    ref: process.env.GITHUB_REF,
+    refName: process.env.GITHUB_REF_NAME,
+    eventNumber: process.env.GITHUB_EVENT_NUMBER,
+    inputs: { branch: process.env.INPUT_BRANCH }
+  };
+  const channelId = getFirebaseChannelId(context);
+  console.log(`Firebase Channel ID: ${channelId}`);
+  if (process.env.GITHUB_OUTPUT) {
+    fs.appendFileSync(process.env.GITHUB_OUTPUT, `channel_id=${channelId}\n`);
+  }
+}

--- a/ExpoGallery/tests/getFirebaseChannelId.test.js
+++ b/ExpoGallery/tests/getFirebaseChannelId.test.js
@@ -1,0 +1,45 @@
+const { getFirebaseChannelId, sanitizeBranchName } = require('../scripts/getFirebaseChannelId');
+
+describe('sanitizeBranchName', () => {
+  test('removes invalid characters and trims', () => {
+    expect(sanitizeBranchName('Feature/ABC_123')).toBe('feature-abc-123');
+    expect(sanitizeBranchName('---Crazy*Branch***')).toBe('crazy-branch');
+    expect(sanitizeBranchName('VeryLongBranchNameThatExceedsThirtySixCharacters')).toBe('verylongbranchnamethatexceedsthirt');
+  });
+});
+
+describe('getFirebaseChannelId', () => {
+  test('push to main uses live', () => {
+    const id = getFirebaseChannelId({ eventName: 'push', ref: 'refs/heads/main' });
+    expect(id).toBe('live');
+  });
+
+  test('push to branch generates preview name', () => {
+    const id = getFirebaseChannelId({ eventName: 'push', ref: 'refs/heads/dev', refName: 'Dev' });
+    expect(id).toBe('preview-dev');
+  });
+
+  test('pull request channel', () => {
+    const id = getFirebaseChannelId({ eventName: 'pull_request', eventNumber: 42 });
+    expect(id).toBe('preview-pr-42');
+  });
+
+  test('workflow_dispatch with main branch uses live', () => {
+    const id = getFirebaseChannelId({ eventName: 'workflow_dispatch', inputs: { branch: 'main' } });
+    expect(id).toBe('live');
+  });
+
+  test('workflow_dispatch with custom branch', () => {
+    const id = getFirebaseChannelId({ eventName: 'workflow_dispatch', inputs: { branch: 'Feature/ABC' } });
+    expect(id).toBe('preview-feature-abc');
+  });
+
+  test('workflow_dispatch with empty branch uses preview-manual', () => {
+    const id = getFirebaseChannelId({ eventName: 'workflow_dispatch', inputs: { branch: '' } });
+    expect(id).toBe('preview-manual');
+  });
+
+  test('unknown event throws error', () => {
+    expect(() => getFirebaseChannelId({ eventName: 'unknown' })).toThrow();
+  });
+});

--- a/setup.sh
+++ b/setup.sh
@@ -1,0 +1,9 @@
+#!/usr/bin/env bash
+set -e
+
+# Install project dependencies
+cd ExpoGallery
+npm ci
+
+# Prepare the environment file expected by scripts and tests
+cp .env.example .env.local


### PR DESCRIPTION
## Summary
- add `getFirebaseChannelId` script to encapsulate channel logic used in workflows
- add unit tests for channel ID calculation

## Testing
- `npm test` *(fails: dotenv not found)*