### PR TITLE
Refactor GitHub Actions to use a reusable build/test workflow

### DIFF
--- a/.github/workflows/deploy-expo-web.yml
+++ b/.github/workflows/deploy-expo-web.yml
@@ -9,7 +9,6 @@ on:
       - main # Only run on PRs targeting the main branch
   workflow_dispatch: # Allow manual triggering of the workflow
 
-# Add permissions needed for GitHub Pages
 permissions:
   contents: read
   pages: write
@@ -21,63 +20,34 @@ env:
   DEFAULT_CHAT_LOCATION: ${{ vars.DEFAULT_CHAT_LOCATION }}
 
 jobs:
-  build-and-deploy:
+  call_reusable_build:
+    uses: ./.github/workflows/reusable-build-test.yml
+    with:
+      node-version: '18'
+      expo-working-directory: 'ExpoGallery'
+      output-path: 'dist'
+
+  deploy_to_pages:
+    needs: call_reusable_build
     runs-on: ubuntu-latest
-
+    # Add environment for GitHub Pages deployment URL
+    environment:
+      name: github-pages
+      url: ${{ steps.deployment.outputs.page_url }}
     steps:
-      - name: Checkout code
-        uses: actions/checkout@v4
-
-      - name: Setup Node.js
-        uses: actions/setup-node@v4
+      - name: Download build artifact
+        uses: actions/download-artifact@v4
         with:
-          node-version: '18' # Use the Node.js version compatible with our Expo version
-          cache: 'npm'
-          cache-dependency-path: 'ExpoGallery/package-lock.json'
-
-      - name: Install dependencies
-        run: |
-          cd ExpoGallery
-          npm ci
-
-      - name: Run tests
-        run: |
-          cd ExpoGallery
-          npm test
-
-      - name: Build Expo web
-        run: |
-          cd ExpoGallery
-          npm run predeploy
-          npx expo export --platform web --no-minify --dev
-          touch dist/.nojekyll
-        env:
-          NODE_OPTIONS: "--max_old_space_size=4096"
-
-      - name: Save latest deployment artifact
-        uses: actions/upload-artifact@v4
-        with:
-          name: expo-web-build-latest
-          path: |
-            ExpoGallery/dist
-            ExpoGallery/public/version.json
-
-      - name: Save historical deployment artifact
-        uses: actions/upload-artifact@v4
-        with:
-          name: expo-web-build-${{ github.sha }}
-          path: |
-            ExpoGallery/dist
-            ExpoGallery/public/version.json
-          retention-days: 90
+          name: ${{ needs.call_reusable_build.outputs.build_artifact_name }}
+          path: downloaded-artifact # Artifact content will be in 'dist' if output-path was 'dist'
 
       - name: Setup Pages
         uses: actions/configure-pages@v4
 
-      - name: Upload artifact
+      - name: Upload artifact for GitHub Pages
         uses: actions/upload-pages-artifact@v3
         with:
-          path: './ExpoGallery/dist'
+          path: './downloaded-artifact/${{ needs.call_reusable_build.outputs.build_output_dir_name }}'
 
       - name: Deploy to GitHub Pages
         id: deployment
@@ -85,15 +55,54 @@ jobs:
 
       - name: Verify deployed SHA
         run: |
-          sudo apt-get update && sudo apt-get install -y jq
-          DEPLOYED_VERSION_URL="${{ steps.deployment.outputs.page_url }}/version.json"
-          echo "Fetching deployed version from: $DEPLOYED_VERSION_URL"
-          DEPLOYED_SHA=$(curl -s $DEPLOYED_VERSION_URL | jq -r '.build')
           EXPECTED_SHA="${{ github.sha }}"
-          echo "Deployed SHA: $DEPLOYED_SHA"
+          # Construct the URL to version.json using the base URL from deployment and the relative path from the reusable workflow's output
+          DEPLOYED_VERSION_URL="${{ steps.deployment.outputs.page_url }}/${{ needs.call_reusable_build.outputs.version_json_relative_path }}"
+          
+          echo "Verifying deployment..."
           echo "Expected SHA: $EXPECTED_SHA"
-          if [ "$DEPLOYED_SHA" != "$EXPECTED_SHA" ]; then
-            echo "Error: Deployed SHA ($DEPLOYED_SHA) does not match expected SHA ($EXPECTED_SHA)."
+          echo "Fetching deployed version from: $DEPLOYED_VERSION_URL"
+          
+          DEPLOYED_SHA=""
+          for i in 1 2 3 4 5; do
+            # Save curl output to a file and capture HTTP status code
+            # Added -L to follow redirects, which can be common for GitHub Pages initial deployment.
+            HTTP_CODE=$(curl -s -L -w "%{http_code}" -o response.json "$DEPLOYED_VERSION_URL")
+            if [ "$HTTP_CODE" -eq 200 ]; then
+              # Check if response.json is not empty and contains valid JSON with a non-null .build field
+              if [ -s response.json ] && jq -e '.build != null' response.json > /dev/null; then
+                DEPLOYED_SHA=$(jq -r '.build' response.json)
+                # Additional check to ensure DEPLOYED_SHA is not empty string after jq
+                if [ -n "$DEPLOYED_SHA" ]; then
+                   echo "Successfully fetched deployed SHA: $DEPLOYED_SHA"
+                   break
+                else
+                   echo "Attempt $i: Fetched 'build' field is empty."
+                fi
+              else
+                echo "Attempt $i: Fetched content is not valid JSON, 'build' key is missing, or 'build' key is null."
+                echo "Response content:"
+                cat response.json
+              fi
+            else
+              echo "Attempt $i: HTTP request failed with status code $HTTP_CODE."
+              # It's useful to see the response body even on HTTP errors, if any.
+              echo "Response content (if any):"
+              cat response.json
+            fi
+            echo "Retrying in 10 seconds..."
+            sleep 10
+          done
+
+          if [ -z "$DEPLOYED_SHA" ] || [ "$DEPLOYED_SHA" == "null" ]; then
+            echo "::error::Could not fetch or parse deployed SHA from $DEPLOYED_VERSION_URL after multiple retries."
+            # response.json was already cat-ed in the loop if it existed
             exit 1
           fi
-          echo "Successfully verified deployed SHA."
+
+          if [ "$DEPLOYED_SHA" != "$EXPECTED_SHA" ]; then
+            echo "::error::Deployed SHA ($DEPLOYED_SHA) does not match expected SHA ($EXPECTED_SHA)."
+            exit 1
+          fi
+          echo "Successfully verified deployed SHA ($DEPLOYED_SHA) on $DEPLOYED_VERSION_URL."
+        shell: bash

--- a/.github/workflows/deploy-firebase.yml
+++ b/.github/workflows/deploy-firebase.yml
@@ -22,70 +22,81 @@ env:
   DEFAULT_CHAT_LOCATION: ${{ vars.DEFAULT_CHAT_LOCATION }}
 
 jobs:
-  test:
+  call_reusable_build:
+    uses: ./.github/workflows/reusable-build-test.yml
+    with:
+      node-version: '20' # Firebase workflow uses Node 20
+      expo-working-directory: 'ExpoGallery'
+      output-path: 'dist' # Standard output path from reusable workflow
+      # cache-dependency-path is not specified, so it will use default from reusable workflow
+    # secrets: inherit # If reusable workflow needed secrets
+
+  build_and_deploy_firebase:
+    needs: call_reusable_build
     runs-on: ubuntu-latest
+    # Removed if: success() because reusable workflow failing will prevent this from running.
     steps:
+      # Checkout code for Firebase tools, firebase.json, and scripts not in artifact.
+      # Also needed for github.sha if not available otherwise, though it should be.
       - name: Checkout code
         uses: actions/checkout@v4
 
-      - name: Setup Node.js
-        uses: actions/setup-node@v4
+      - name: Download build artifact
+        uses: actions/download-artifact@v4
         with:
-          node-version: '20' # Consistent with other workflows
-          cache: 'npm'
-          cache-dependency-path: 'ExpoGallery/package-lock.json'
+          name: ${{ needs.call_reusable_build.outputs.build_artifact_name }}
+          path: downloaded-artifact # Downloads to ./downloaded-artifact/
 
-      - name: Install dependencies
+      - name: Prepare Firebase deployment directory
         run: |
-          cd ExpoGallery
-          npm ci
+          mkdir -p site/public
+          echo "Copying from ./downloaded-artifact/${{ needs.call_reusable_build.outputs.build_output_dir_name }} to ./site/public/"
+          # This line assumes 'downloaded-artifact' contains a subdirectory matching 'build_output_dir_name' (e.g. 'dist')
+          cp -r ./downloaded-artifact/${{ needs.call_reusable_build.outputs.build_output_dir_name }}/* ./site/public/
+          # Verify version.json is in the right place for Firebase
+          # If build_output_dir_name is 'dist' and version_json_relative_path is 'public/version.json',
+          # this expects version.json at site/public/public/version.json
+          echo "Expected version.json at: ./site/public/${{ needs.call_reusable_build.outputs.version_json_relative_path }}"
+          ls -l ./site/public/${{ needs.call_reusable_build.outputs.version_json_relative_path }}
 
-      - name: Run tests
-        run: |
-          cd ExpoGallery
-          npm test
-
-  build_and_deploy:
-    runs-on: ubuntu-latest
-    needs: test
-    if: success() # Only run if tests pass
-    steps:
-      - name: Checkout code
-        uses: actions/checkout@v4
-
-      - name: Setup Node.js
-        uses: actions/setup-node@v4
-        with:
-          node-version: '20' # Consistent with test job
-          cache: 'npm'
-          cache-dependency-path: 'ExpoGallery/package-lock.json'
-
-      - name: Install dependencies
-        run: |
-          cd ExpoGallery
-          npm ci
 
       - name: Determine Firebase Channel ID
         id: channel_id
         run: |
+          # Determine Firebase Channel ID based on GitHub event context
           CHANNEL_ID=""
+          # Sanitize branch name function (example, actual commands are in if/else)
+          # sanitize_branch_name() {
+          #   echo "$1" | tr '[:upper:]' '[:lower:]' | sed 's/[^a-z0-9-]/-/g' | cut -c1-36 | sed 's/^-*\(.*[^-]\)-*$//'
+          # }
+
           if [ "${{ github.event_name }}" == "push" ] && [ "${{ github.ref }}" == "refs/heads/main" ]; then
+            # Deployments to main branch go to the 'live' channel
             CHANNEL_ID="live"
           elif [ "${{ github.event_name }}" == "push" ]; then
-            BRANCH_NAME=$(echo "${{ github.ref_name }}" | tr '[:upper:]' '[:lower:]' | sed 's/[^a-z0-9-]/-/g' | cut -c1-36 | sed 's/^-*\(.*[^-]\)-*$/\1/')
-            if [ -z "$BRANCH_NAME" ]; then BRANCH_NAME="preview"; fi
+            # Pushes to other branches create/update a preview channel
+            # Sanitize branch name:
+            # 1. Convert to lowercase (tr '[:upper:]' '[:lower:]')
+            # 2. Replace non-alphanumeric characters (excluding hyphens) with a hyphen (sed 's/[^a-z0-9-]/-/g')
+            # 3. Truncate to 36 characters (cut -c1-36)
+            # 4. Remove leading/trailing hyphens (sed 's/^-*\(.*[^-]\)-*$//')
+            BRANCH_NAME=$(echo "${{ github.ref_name }}" | tr '[:upper:]' '[:lower:]' | sed 's/[^a-z0-9-]/-/g' | cut -c1-36 | sed 's/^-*\(.*[^-]\)-*$//')
+            if [ -z "$BRANCH_NAME" ]; then BRANCH_NAME="preview"; fi # Default if branch name is empty after sanitization
             CHANNEL_ID="preview-$BRANCH_NAME"
           elif [ "${{ github.event_name }}" == "pull_request" ]; then
+            # Pull requests also create/update a preview channel named after the PR number
             CHANNEL_ID="preview-pr-${{ github.event.number }}"
           elif [ "${{ github.event_name }}" == "workflow_dispatch" ]; then
-            BRANCH_NAME=$(echo "${{ github.event.inputs.branch }}" | tr '[:upper:]' '[:lower:]' | sed 's/[^a-z0-9-]/-/g' | cut -c1-36 | sed 's/^-*\(.*[^-]\)-*$/\1/')
-            NORMALIZED_BRANCH=$(echo "${{ github.event.inputs.branch }}" | tr '[:upper:]' '[:lower:]')
-            if [ "$NORMALIZED_BRANCH" == "main" ]; then
-                CHANNEL_ID="live"
+            # Manual workflow runs
+            # Sanitize the input branch name using the same logic as for push events
+            BRANCH_NAME=$(echo "${{ github.event.inputs.branch }}" | tr '[:upper:]' '[:lower:]' | sed 's/[^a-z0-9-]/-/g' | cut -c1-36 | sed 's/^-*\(.*[^-]\)-*$//')
+            NORMALIZED_BRANCH_INPUT=$(echo "${{ github.event.inputs.branch }}" | tr '[:upper:]' '[:lower:]') # For 'main' check
+            if [ "$NORMALIZED_BRANCH_INPUT" == "main" ]; then
+              CHANNEL_ID="live" # Manual dispatch for main branch also goes to live
             elif [ -z "$BRANCH_NAME" ]; then 
-                CHANNEL_ID="preview-manual"
+              CHANNEL_ID="preview-manual" # Default for empty/invalid manual input
             else
-                CHANNEL_ID="preview-$BRANCH_NAME"
+              CHANNEL_ID="preview-$BRANCH_NAME"
             fi
           else
             echo "::error::Unknown event type or context for Firebase deployment."
@@ -94,26 +105,17 @@ jobs:
           echo "Firebase Channel ID: $CHANNEL_ID"
           echo "channel_id=$CHANNEL_ID" >> $GITHUB_OUTPUT
 
-      - name: Build Expo web
+      - name: Replace GITHUB_SHA in about.html
+        # working-directory is now ./site/public, so paths are relative to that
+        working-directory: ./site/public
         run: |
-          cd ExpoGallery
-          npm run predeploy:root
-          # The output directory needs to be relative to the entryPoint for Firebase deploy action
-          npx expo export --platform web --dev --output-dir ../site/public
-        env:
-          NODE_OPTIONS: "--max_old_space_size=4096"
-
-      - name: Replace GITHUB_SHA in about.html and version.json
-        run: |
-          cd site/public
           if [ -f "about.html" ]; then
+            echo "Replacing GITHUB_SHA in about.html with ${{ github.sha }}"
+            # sed -i.bak modifies the file in place and creates a backup with .bak extension
             sed -i.bak 's/GITHUB_SHA/'${GITHUB_SHA}'/g' about.html
+          else
+            echo "about.html not found in current directory (expected ./site/public/about.html)"
           fi
-          # Create or update version.json with the current SHA
-          echo "{\"build\": \"${GITHUB_SHA}\"}" > version.json
-          echo "Generated version.json with SHA: ${GITHUB_SHA}"
-          cat version.json
-        working-directory: . # Run from repo root so site/public path is correct
 
       - name: Deploy to Firebase Hosting
         uses: FirebaseExtended/action-hosting-deploy@v0
@@ -131,15 +133,16 @@ jobs:
           FIREBASE_PROJECT_ID: mapchatai
           FIREBASE_DEPLOY_DETAILS: ${{ steps.firebase_deploy.outputs.details }}
         run: |
-          sudo apt-get update && sudo apt-get install -y jq # Keep this line
-          echo "Firebase Deploy Details: $FIREBASE_DEPLOY_DETAILS" # For debugging
+          # GITHUB_SHA for comparison is from the commit that triggered this overall workflow
+          EXPECTED_SHA="${{ github.sha }}"
+          
+          sudo apt-get update && sudo apt-get install -y jq
+          echo "Firebase Deploy Details: $FIREBASE_DEPLOY_DETAILS"
 
           ACTUAL_SITE_URL=""
           if [ "$CHANNEL_ID_OUTPUT" == "live" ]; then
             ACTUAL_SITE_URL=$(echo "$FIREBASE_DEPLOY_DETAILS" | jq -r --arg project_id "$FIREBASE_PROJECT_ID" '.[$project_id].live.url')
           else
-            # Find the key that starts with the CHANNEL_ID_OUTPUT (e.g., "preview-dev")
-            # The channel ID from firebase_deploy details might have a suffix (e.g., "preview-dev-randomsuffix")
             ACTUAL_SITE_URL=$(echo "$FIREBASE_DEPLOY_DETAILS" | jq -r --arg project_id "$FIREBASE_PROJECT_ID" --arg channel_prefix "$CHANNEL_ID_OUTPUT" '.[$project_id] | to_entries[] | select(.key | startswith($channel_prefix)) | .value.url')
           fi
 
@@ -148,28 +151,36 @@ jobs:
             exit 1
           fi
 
-          DEPLOYED_VERSION_URL="$ACTUAL_SITE_URL/version.json"
+          # version_json_relative_path from reusable workflow is relative to the build output dir.
+          # e.g., public/version.json. This is correct for constructing the URL.
+          DEPLOYED_VERSION_URL="$ACTUAL_SITE_URL/${{ needs.call_reusable_build.outputs.version_json_relative_path }}"
           echo "Fetching deployed version from: $DEPLOYED_VERSION_URL"
+          
+          DEPLOYED_SHA=""
           for i in 1 2 3 4 5; do
-            HTTP_CODE=$(curl -s -w "%{http_code}" -o response.json $DEPLOYED_VERSION_URL)
+            HTTP_CODE=$(curl -s -w "%{http_code}" -o response.json "$DEPLOYED_VERSION_URL")
             if [ "$HTTP_CODE" -eq 200 ]; then
               DEPLOYED_SHA=$(jq -r '.build' response.json)
               if [ -n "$DEPLOYED_SHA" ] && [ "$DEPLOYED_SHA" != "null" ]; then
+                echo "Successfully fetched deployed SHA: $DEPLOYED_SHA"
                 break
               fi
             fi
-            echo "Attempt $i: Failed to fetch or parse version.json (HTTP: $HTTP_CODE). Retrying in 10 seconds..."
+            echo "Attempt $i: Failed to fetch or parse version.json (HTTP: $HTTP_CODE) from $DEPLOYED_VERSION_URL. Retrying in 10 seconds..."
             sleep 10
           done
-          EXPECTED_SHA="${{ github.sha }}"
-          echo "Deployed SHA: $DEPLOYED_SHA"
-          echo "Expected SHA: $EXPECTED_SHA"
+
           if [ -z "$DEPLOYED_SHA" ] || [ "$DEPLOYED_SHA" == "null" ]; then
             echo "::error::Could not fetch deployed SHA from $DEPLOYED_VERSION_URL after multiple retries."
+            cat response.json # Output content of response.json for debugging
             exit 1
           fi
+          
+          echo "Deployed SHA: $DEPLOYED_SHA"
+          echo "Expected SHA: $EXPECTED_SHA"
           if [ "$DEPLOYED_SHA" != "$EXPECTED_SHA" ]; then
             echo "::error::Deployed SHA ($DEPLOYED_SHA) does not match expected SHA ($EXPECTED_SHA)."
             exit 1
           fi
           echo "Successfully verified deployed SHA on $DEPLOYED_VERSION_URL"
+        shell: bash

--- a/.github/workflows/reusable-build-test.yml
+++ b/.github/workflows/reusable-build-test.yml
@@ -1,0 +1,101 @@
+name: Reusable Expo Web Build and Test
+
+on:
+  workflow_call:
+    inputs:
+      node-version:
+        description: 'Node.js version to use'
+        required: false
+        type: string
+        default: '18'
+      cache-dependency-path:
+        description: 'Path to package-lock.json or similar for caching'
+        required: false
+        type: string
+        default: 'ExpoGallery/package-lock.json'
+      expo-working-directory:
+        description: 'Directory where Expo project is located'
+        required: false
+        type: string
+        default: 'ExpoGallery'
+      output-path:
+        description: 'Directory relative to expo-working-directory to output the build artifacts'
+        required: false
+        type: string
+        default: 'dist'
+    outputs:
+      build_artifact_name:
+        description: "The name of the uploaded build artifact."
+        value: ${{ jobs.build_and_test.outputs.job_build_artifact_name }}
+      build_output_dir_name:
+        description: "The name of the directory containing the build output, relative to the artifact root (this is the value of inputs.output-path)."
+        value: ${{ inputs.output-path }}
+      version_json_relative_path:
+        description: "Relative path to version.json within the build output directory (e.g., public/version.json)."
+        value: "public/version.json"
+
+jobs:
+  build_and_test:
+    runs-on: ubuntu-latest
+    outputs:
+      job_build_artifact_name: expo-web-build-${{ github.run_id }}
+      # The following are not strictly needed as job outputs if workflow outputs can derive them from inputs
+      # but defining them for clarity if direct reference from job is ever preferred.
+      # For this setup, workflow outputs directly use inputs or fixed values where appropriate.
+      # job_build_output_path_relative: ${{ inputs.output-path }} # This is the name of the folder, e.g. "dist"
+      # job_version_json_path_relative: public/version.json # Relative to the output-path
+
+    steps:
+      - name: Checkout code
+        uses: actions/checkout@v4
+
+      - name: Setup Node.js
+        uses: actions/setup-node@v4
+        with:
+          node-version: ${{ inputs.node-version }}
+          cache: 'npm'
+          cache-dependency-path: ${{ inputs.cache-dependency-path }}
+
+      - name: Install dependencies
+        run: |
+          cd ${{ inputs.expo-working-directory }}
+          npm ci
+
+      - name: Run tests
+        run: |
+          cd ${{ inputs.expo-working-directory }}
+          npm test
+
+      - name: Run predeploy script
+        run: |
+          cd ${{ inputs.expo-working-directory }}
+          npm run predeploy 
+          # This script is expected to copy assets/index.html to ${{ inputs.output-path }}/
+          # and potentially an initial assets/version.json to ${{ inputs.output-path }}/public/
+
+      - name: Create/Overwrite version.json
+        run: |
+          cd ${{ inputs.expo-working-directory }}
+          mkdir -p ${{ inputs.output-path }}/public
+          echo '{"build": "${{ github.sha }}"}' > ${{ inputs.output-path }}/public/version.json
+        shell: bash
+
+      - name: Build Expo web application
+        env:
+          NODE_OPTIONS: "--max_old_space_size=4096"
+        run: |
+          cd ${{ inputs.expo-working-directory }}
+          npx expo export --platform web --no-minify --dev --output-dir ./${{ inputs.output-path }}
+
+      - name: Create .nojekyll file
+        run: |
+          touch ${{ inputs.expo-working-directory }}/${{ inputs.output-path }}/.nojekyll
+        shell: bash
+
+      - name: Upload build artifact
+        uses: actions/upload-artifact@v4
+        with:
+          name: expo-web-build-${{ github.run_id }}
+          path: ${{ inputs.expo-working-directory }}/${{ inputs.output-path }}
+          if-no-files-found: error # Fail the workflow if the build output is missing
+          retention-days: 7 # Optional: configure how long to keep the artifact

--- a/.github/workflows/run-tests.yml
+++ b/.github/workflows/run-tests.yml
@@ -12,35 +12,13 @@ env:
   DEFAULT_CHAT_LOCATION: ${{ vars.DEFAULT_CHAT_LOCATION }}
 
 jobs:
-  test-and-build:
-    runs-on: ubuntu-latest
-
-    steps:
-      - name: Checkout code
-        uses: actions/checkout@v4
-
-      - name: Setup Node.js
-        uses: actions/setup-node@v4
-        with:
-          node-version: '18' # Use the Node.js version compatible with our Expo version
-          cache: 'npm'
-          cache-dependency-path: 'ExpoGallery/package-lock.json'
-
-      - name: Install dependencies
-        run: |
-          cd ExpoGallery
-          npm ci
-
-      - name: Run tests
-        run: |
-          cd ExpoGallery
-          npm test
-
-      - name: Build Expo web
-        run: |
-          cd ExpoGallery
-          npm run predeploy
-          npx expo export --platform web --no-minify --dev
-          touch dist/.nojekyll
-        env:
-          NODE_OPTIONS: "--max_old_space_size=4096"
+  run_build_and_tests_via_reusable_workflow: # Renamed job for clarity
+    uses: ./.github/workflows/reusable-build-test.yml
+    with:
+      node-version: '18'
+      expo-working-directory: 'ExpoGallery'
+      output-path: 'dist' # Standard output path, though not used here
+      cache-dependency-path: 'ExpoGallery/package-lock.json'
+    # If the reusable workflow needed secrets for the build/test process:
+    # secrets:
+    #   SOME_SECRET: ${{ secrets.SOME_SECRET_IN_CALLER }}


### PR DESCRIPTION
This change introduces a reusable GitHub Actions workflow (`reusable-build-test.yml`) to consolidate common tasks like Node.js setup, dependency installation, running tests, and building the Expo web application.

The following workflows have been updated to use this reusable workflow:
- `deploy-expo-web.yml`: Now calls the reusable workflow for build and test steps, then proceeds with GitHub Pages deployment.
- `deploy-firebase.yml`: Now calls the reusable workflow for build and test steps, then prepares the output for Firebase and deploys.
- `run-tests.yml`: Now entirely delegates its operations to the reusable workflow.

Key improvements:
- Reduced duplication of build and test logic across multiple workflow files.
- Simplified individual workflow files, making them easier to understand and maintain.
- Standardized the generation of `version.json`, which is now consistently created by the reusable workflow and includes the commit SHA.
- Improved clarity in `deploy-firebase.yml` with added comments for complex scripts.

The `protect-main-prs.yml` workflow was examined and required no changes as its function is distinct and does not overlap with build/test operations. Testing of the reusable workflow is achieved through the successful execution and verification steps within the calling workflows.