### PR TITLE
Fix artifact path in Firebase deploy workflow

### DIFF
--- a/.github/workflows/deploy-expo-web.yml
+++ b/.github/workflows/deploy-expo-web.yml
@@ -39,7 +39,7 @@ jobs:
         uses: actions/download-artifact@v4
         with:
           name: ${{ needs.call_reusable_build.outputs.build_artifact_name }}
-          path: downloaded-artifact # Artifact content will be in 'dist' if output-path was 'dist'
+          path: downloaded-artifact # Artifact content will include the Expo project directory
 
       - name: Setup Pages
         uses: actions/configure-pages@v4
@@ -47,7 +47,7 @@ jobs:
       - name: Upload artifact for GitHub Pages
         uses: actions/upload-pages-artifact@v3
         with:
-          path: './downloaded-artifact/${{ needs.call_reusable_build.outputs.build_output_dir_name }}'
+          path: './downloaded-artifact/ExpoGallery/${{ needs.call_reusable_build.outputs.build_output_dir_name }}'
 
       - name: Deploy to GitHub Pages
         id: deployment

--- a/.github/workflows/deploy-firebase.yml
+++ b/.github/workflows/deploy-firebase.yml
@@ -50,9 +50,10 @@ jobs:
       - name: Prepare Firebase deployment directory
         run: |
           mkdir -p site/public
-          echo "Copying from ./downloaded-artifact/${{ needs.call_reusable_build.outputs.build_output_dir_name }} to ./site/public/"
-          # This line assumes 'downloaded-artifact' contains a subdirectory matching 'build_output_dir_name' (e.g. 'dist')
-          cp -r ./downloaded-artifact/${{ needs.call_reusable_build.outputs.build_output_dir_name }}/* ./site/public/
+          echo "Copying from ./downloaded-artifact/ExpoGallery/${{ needs.call_reusable_build.outputs.build_output_dir_name }} to ./site/public/"
+          # The artifact retains the Expo project directory (ExpoGallery) when uploaded
+          # so the build output is under ./downloaded-artifact/ExpoGallery/<output-path>
+          cp -r ./downloaded-artifact/ExpoGallery/${{ needs.call_reusable_build.outputs.build_output_dir_name }}/* ./site/public/
           # Verify version.json is in the right place for Firebase
           # If build_output_dir_name is 'dist' and version_json_relative_path is 'public/version.json',
           # this expects version.json at site/public/public/version.json

--- a/.github/workflows/manual-deploy-firebase.yml
+++ b/.github/workflows/manual-deploy-firebase.yml
@@ -37,8 +37,9 @@ jobs:
       - name: Prepare Firebase deployment directory
         run: |
           mkdir -p site/public
-          echo "Copying from ./downloaded-artifact/${{ needs.call_reusable_build.outputs.build_output_dir_name }} to ./site/public/"
-          cp -r ./downloaded-artifact/${{ needs.call_reusable_build.outputs.build_output_dir_name }}/* ./site/public/
+          echo "Copying from ./downloaded-artifact/ExpoGallery/${{ needs.call_reusable_build.outputs.build_output_dir_name }} to ./site/public/"
+          # Artifact retains the Expo project directory
+          cp -r ./downloaded-artifact/ExpoGallery/${{ needs.call_reusable_build.outputs.build_output_dir_name }}/* ./site/public/
           echo "Expected version.json at: ./site/public/${{ needs.call_reusable_build.outputs.version_json_relative_path }}"
           ls -l ./site/public/${{ needs.call_reusable_build.outputs.version_json_relative_path }}
 


### PR DESCRIPTION
## Summary
- copy build artifacts from the correct directory when deploying to Firebase or GitHub Pages
- adjust manual Firebase deploy workflow accordingly

## Testing
- `npm test`