### PR TITLE
Fix firebase deploy directory path

### DIFF
--- a/.github/workflows/deploy-expo-web.yml
+++ b/.github/workflows/deploy-expo-web.yml
@@ -47,7 +47,7 @@ jobs:
       - name: Upload artifact for GitHub Pages
         uses: actions/upload-pages-artifact@v3
         with:
-          path: './downloaded-artifact/ExpoGallery/${{ needs.call_reusable_build.outputs.build_output_dir_name }}'
+          path: './downloaded-artifact/${{ needs.call_reusable_build.outputs.build_output_dir_name }}'
 
       - name: Deploy to GitHub Pages
         id: deployment

--- a/.github/workflows/deploy-firebase.yml
+++ b/.github/workflows/deploy-firebase.yml
@@ -47,9 +47,8 @@ jobs:
 
       - name: Prepare Firebase deployment directory
         run: |
-          node ExpoGallery/scripts/prepareFirebaseDir.js \
-            "downloaded-artifact/ExpoGallery/${{ needs.call_reusable_build.outputs.build_output_dir_name }}" \
-            site/public \
+          node ExpoGallery/scripts/prepareFirebaseDirFromArtifact.js \
+            "${{ needs.call_reusable_build.outputs.build_output_dir_name }}" \
             "${{ needs.call_reusable_build.outputs.version_json_relative_path }}"
 
 

--- a/.github/workflows/manual-deploy-firebase.yml
+++ b/.github/workflows/manual-deploy-firebase.yml
@@ -36,9 +36,8 @@ jobs:
 
       - name: Prepare Firebase deployment directory
         run: |
-          node ExpoGallery/scripts/prepareFirebaseDir.js \
-            "downloaded-artifact/ExpoGallery/${{ needs.call_reusable_build.outputs.build_output_dir_name }}" \
-            site/public \
+          node ExpoGallery/scripts/prepareFirebaseDirFromArtifact.js \
+            "${{ needs.call_reusable_build.outputs.build_output_dir_name }}" \
             "${{ needs.call_reusable_build.outputs.version_json_relative_path }}"
 
       - name: Determine Firebase Channel ID

--- a/ExpoGallery/scripts/prepareFirebaseDirFromArtifact.js
+++ b/ExpoGallery/scripts/prepareFirebaseDirFromArtifact.js
@@ -1,0 +1,19 @@
+const { prepareFirebaseDir } = require('./prepareFirebaseDir');
+
+function run(buildOutputDirName, versionJsonRelativePath) {
+  const sourceDir = `downloaded-artifact/${buildOutputDirName}`;
+  const destDir = 'site/public';
+  prepareFirebaseDir(sourceDir, destDir, versionJsonRelativePath);
+}
+
+if (require.main === module) {
+  const [,, buildDir, versionRel] = process.argv;
+  try {
+    run(buildDir, versionRel);
+  } catch (err) {
+    console.error(err.message);
+    process.exit(1);
+  }
+}
+
+module.exports = { run };


### PR DESCRIPTION
## Summary
- fix artifact path when preparing Firebase deployment directory
- also update Expo Pages deploy step
- extract common Firebase dir preparation step to new script

## Testing
- `npm test`
