### PR TITLE
Fix Firebase deploy path

### DIFF
--- a/.github/workflows/deploy-firebase.yml
+++ b/.github/workflows/deploy-firebase.yml
@@ -48,6 +48,7 @@ jobs:
       - name: Prepare Firebase deployment directory
         run: |
           node ExpoGallery/scripts/prepareFirebaseDirFromArtifact.js \
+            "${{ needs.call_reusable_build.outputs.build_artifact_name }}" \
             "${{ needs.call_reusable_build.outputs.build_output_dir_name }}" \
             "${{ needs.call_reusable_build.outputs.version_json_relative_path }}"
 

--- a/.github/workflows/manual-deploy-firebase.yml
+++ b/.github/workflows/manual-deploy-firebase.yml
@@ -37,6 +37,7 @@ jobs:
       - name: Prepare Firebase deployment directory
         run: |
           node ExpoGallery/scripts/prepareFirebaseDirFromArtifact.js \
+            "${{ needs.call_reusable_build.outputs.build_artifact_name }}" \
             "${{ needs.call_reusable_build.outputs.build_output_dir_name }}" \
             "${{ needs.call_reusable_build.outputs.version_json_relative_path }}"
 

--- a/ExpoGallery/scripts/prepareFirebaseDir.js
+++ b/ExpoGallery/scripts/prepareFirebaseDir.js
@@ -3,10 +3,16 @@ const path = require('path');
 
 function prepareFirebaseDir(sourceDir, destDir, versionJsonRelativePath = 'public/version.json') {
   if (!fs.existsSync(sourceDir)) {
+    const parent = path.dirname(sourceDir);
+    if (fs.existsSync(parent)) {
+      const entries = fs.readdirSync(parent);
+      console.error(`Available entries in ${parent}: ${entries.join(', ')}`);
+    }
     throw new Error(`Source directory ${sourceDir} does not exist`);
   }
   fs.mkdirSync(destDir, { recursive: true });
   // Copy contents of sourceDir into destDir
+  console.log(`Copying ${sourceDir} -> ${destDir}`);
   fs.cpSync(sourceDir, destDir, { recursive: true });
   const expectedPath = path.join(destDir, versionJsonRelativePath);
   console.log(`Expected version.json at: ${expectedPath}`);

--- a/ExpoGallery/scripts/prepareFirebaseDirFromArtifact.js
+++ b/ExpoGallery/scripts/prepareFirebaseDirFromArtifact.js
@@ -1,15 +1,31 @@
+const fs = require('fs');
+const path = require('path');
 const { prepareFirebaseDir } = require('./prepareFirebaseDir');
 
-function run(buildOutputDirName, versionJsonRelativePath) {
-  const sourceDir = `downloaded-artifact/${buildOutputDirName}`;
+function run(buildArtifactName, buildOutputDirName, versionJsonRelativePath) {
+  const artifactDir = path.join('downloaded-artifact', buildArtifactName);
+  const sourceDir = path.join(artifactDir, buildOutputDirName);
   const destDir = 'site/public';
+
+  console.log(`Preparing Firebase directory`);
+  console.log(`- Artifact directory: ${artifactDir}`);
+  console.log(`- Build output directory: ${buildOutputDirName}`);
+  console.log(`- Source directory resolved to: ${sourceDir}`);
+
+  if (fs.existsSync('downloaded-artifact')) {
+    const entries = fs.readdirSync('downloaded-artifact');
+    console.log(`Contents of downloaded-artifact: ${entries.join(', ')}`);
+  } else {
+    console.log('downloaded-artifact directory does not exist');
+  }
+
   prepareFirebaseDir(sourceDir, destDir, versionJsonRelativePath);
 }
 
 if (require.main === module) {
-  const [,, buildDir, versionRel] = process.argv;
+  const [,, artifactName, buildDir, versionRel] = process.argv;
   try {
-    run(buildDir, versionRel);
+    run(artifactName, buildDir, versionRel);
   } catch (err) {
     console.error(err.message);
     process.exit(1);


### PR DESCRIPTION
## Summary
- correct source path for Firebase deploys by including the artifact name
- add debug logging to help diagnose any future deployment issues

## Testing
- `npm test`
