### PR TITLE
Fix: Adjust script to handle artifact download path

### DIFF
--- a/ExpoGallery/scripts/prepareFirebaseDirFromArtifact.js
+++ b/ExpoGallery/scripts/prepareFirebaseDirFromArtifact.js
@@ -31,12 +31,22 @@ function run(buildArtifactName, buildOutputDirName, versionJsonRelativePath) {
     }
   }
 
-  if (!artifactDir) {
-    throw new Error(`Unable to locate ${buildOutputDirName} in any expected directory`);
+  let sourceDir;
+  if (artifactDir) {
+    sourceDir = path.join(artifactDir, buildOutputDirName);
+    console.log(`- Using source directory: ${sourceDir}`);
+  } else {
+    const potentialRootPath = baseDir;
+    console.log(`- ${buildOutputDirName} not found as subdirectory. Checking if ${potentialRootPath} is the build output directory.`);
+    if (fs.existsSync(path.join(potentialRootPath, versionJsonRelativePath))) {
+      sourceDir = potentialRootPath;
+      console.log(`- Treating ${potentialRootPath} as the build output directory.`);
+    } else {
+      throw new Error(
+        `Unable to locate ${buildOutputDirName} in any expected directory, and ${potentialRootPath} does not appear to be it either (missing ${versionJsonRelativePath}).`
+      );
+    }
   }
-
-  const sourceDir = path.join(artifactDir, buildOutputDirName);
-  console.log(`- Using source directory: ${sourceDir}`);
 
   prepareFirebaseDir(sourceDir, destDir, versionJsonRelativePath);
 }


### PR DESCRIPTION
The deploy-firebase.yml workflow uses actions/download-artifact@v4. When a named artifact is downloaded to a specified path, the contents of the artifact are placed directly into that path.

The prepareFirebaseDirFromArtifact.js script was expecting the build output directory (e.g., "dist") to be a subdirectory within the downloaded path. This change updates the script to also check if the download path itself (e.g., "downloaded-artifact") is the build output directory. This is verified by checking for the existence of version.json at the expected relative path (e.g., public/version.json) within the download path.

This ensures the script correctly locates the build files for Firebase deployment.